### PR TITLE
add (optional) support for more complex lua modulefiles

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,9 +1,11 @@
 PREFIX 	  ?= /usr
 REALPREFIX = $(realpath $(PREFIX))
 CC         = gcc
-CFLAGS     = -std=c99 -Wall -Werror -Wno-format-security -pedantic -O3 -DMII_RELEASE -DMII_PREFIX="\"$(REALPREFIX)\"" -DMII_BUILD_TIME="\"$(shell date)\""
-LDFLAGS    = -llua
+CFLAGS     = -std=c99 -Wall -Werror -Wno-format-security -pedantic -O3 -DMII_PREFIX="\"$(REALPREFIX)\"" -DMII_BUILD_TIME="\"$(shell date)\""
+LDFLAGS    =
 OUTPUT     = mii
+
+MII_ENABLE_LUA ?= no
 
 SOURCES = $(wildcard src/*.c) src/xxhash/xxhash.c
 OBJECTS = $(SOURCES:.c=.o)
@@ -12,7 +14,14 @@ LUASOURCES = $(wildcard src/lua/*.lua)
 LUAOUTPUT  = sandbox.luac
 LUAC       = luac
 
+ifeq ($(MII_ENABLE_LUA), yes)
+CFLAGS  += -DMII_ENABLE_LUA
+LDFLAGS += -llua
+
 all: $(OUTPUT) $(LUAOUTPUT)
+else
+all: $(OUTPUT)
+endif
 
 $(OUTPUT): $(OBJECTS)
 	$(CC) $(OBJECTS) $(LDFLAGS) -o $(OUTPUT)
@@ -29,7 +38,10 @@ clean:
 install: $(OUTPUT) $(LUAOUTPUT)
 	@echo "Installing mii to $(PREFIX)"
 	mkdir -p $(PREFIX)/bin
-	mkdir -p $(PREFIX)/share/mii/lua
+	mkdir -p $(PREFIX)/share/mii
 	cp $(OUTPUT) $(PREFIX)/bin
-	cp $(LUAOUTPUT) $(PREFIX)/share/mii/lua
 	cp -r init  $(PREFIX)/share/mii
+ifeq ($(MII_ENABLE_MII), yes)
+	mkdir -p $(PREFIX)/share/mii/lua
+	cp $(LUAOUTPUT) $(PREFIX)/share/mii/lua
+endif

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 PREFIX 	  ?= /usr
 REALPREFIX = $(realpath $(PREFIX))
 CC         = gcc
-CFLAGS     = -std=c99 -Wall -Werror -Wno-format-security -pedantic -O3 -DMII_PREFIX="\"$(REALPREFIX)\"" -DMII_BUILD_TIME="\"$(shell date)\""
+CFLAGS     = -std=c99 -Wall -Werror -Wno-format-security -pedantic -O3 -DMII_RELEASE -DMII_PREFIX="\"$(REALPREFIX)\"" -DMII_BUILD_TIME="\"$(shell date)\""
 LDFLAGS    =
 OUTPUT     = mii
 

--- a/makefile
+++ b/makefile
@@ -3,45 +3,45 @@ REALPREFIX = $(realpath $(PREFIX))
 CC         = gcc
 CFLAGS     = -std=c99 -Wall -Werror -Wno-format-security -pedantic -O3 -DMII_RELEASE -DMII_PREFIX="\"$(REALPREFIX)\"" -DMII_BUILD_TIME="\"$(shell date)\""
 LDFLAGS    =
-OUTPUT     = mii
+C_OUTPUT   = mii
+OUTPUTS    = $(C_OUTPUT)
 
 MII_ENABLE_LUA ?= no
 
-SOURCES = $(wildcard src/*.c) src/xxhash/xxhash.c
-OBJECTS = $(SOURCES:.c=.o)
+C_SOURCES = $(wildcard src/*.c) src/xxhash/xxhash.c
+C_OBJECTS = $(C_SOURCES:.c=.o)
 
-LUASOURCES = $(wildcard src/lua/*.lua)
-LUAOUTPUT  = sandbox.luac
-LUAC       = luac
+LUA_SOURCES = $(wildcard src/lua/*.lua)
+LUA_OUTPUT  = sandbox.luac
+LUAC        = luac
 
 ifeq ($(MII_ENABLE_LUA), yes)
 CFLAGS  += -DMII_ENABLE_LUA
 LDFLAGS += -llua
-
-all: $(OUTPUT) $(LUAOUTPUT)
-else
-all: $(OUTPUT)
+OUTPUTS += $(LUA_OUTPUT)
 endif
 
-$(OUTPUT): $(OBJECTS)
-	$(CC) $(OBJECTS) $(LDFLAGS) -o $(OUTPUT)
+all: $(OUTPUTS)
+
+$(C_OUTPUT): $(C_OBJECTS)
+	$(CC) $(C_OBJECTS) $(LDFLAGS) -o $(C_OUTPUT)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
-$(LUAOUTPUT): $(LUASOURCES)
+$(LUA_OUTPUT): $(LUA_SOURCES)
 	$(LUAC) -o $@ $?
 
 clean:
-	rm -f $(OUTPUT) $(LUAOUTPUT) $(OBJECTS)
+	rm -f $(C_OUTPUT) $(LUA_OUTPUT) $(C_OBJECTS)
 
-install: $(OUTPUT) $(LUAOUTPUT)
+install: $(OUTPUTS)
 	@echo "Installing mii to $(PREFIX)"
 	mkdir -p $(PREFIX)/bin
 	mkdir -p $(PREFIX)/share/mii
-	cp $(OUTPUT) $(PREFIX)/bin
+	cp $(C_OUTPUT) $(PREFIX)/bin
 	cp -r init  $(PREFIX)/share/mii
-ifeq ($(MII_ENABLE_MII), yes)
+ifeq ($(MII_ENABLE_LUA), yes)
 	mkdir -p $(PREFIX)/share/mii/lua
-	cp $(LUAOUTPUT) $(PREFIX)/share/mii/lua
+	cp $(LUA_OUTPUT) $(PREFIX)/share/mii/lua
 endif

--- a/src/analysis.c
+++ b/src/analysis.c
@@ -34,6 +34,9 @@ static lua_State *lua_state;
 
 /* number of paths to scan for a given modulefile */
 static int num_paths;
+
+/* run lua module code in a sandbox */
+char** _mii_analysis_lua_run(lua_State* lua_state, const char* code);
 #endif
 
 /* word expansion functions */

--- a/src/analysis.c
+++ b/src/analysis.c
@@ -48,7 +48,7 @@ int _mii_analysis_scan_path(char* path, char*** bins_out, int* num_bins_out);
 
 #if !MII_ENABLE_LUA
 /*
- * initialize regexes
+ * compile regexes
  */
 int mii_analysis_init() {
     if (regcomp(&_mii_analysis_lmod_regex, _mii_analysis_lmod_regex_src, REG_EXTENDED | REG_NEWLINE)) {
@@ -92,7 +92,7 @@ int mii_analysis_init() {
 #endif
 
 /*
- * close lua interpreter
+ * cleanup regexes or lua interpreter
  */
 void mii_analysis_free() {
 #if !MII_ENABLE_LUA


### PR DESCRIPTION
This PR makes the Lua API for C dependency optional. The feature using this dependency is disabled by default and can be enabled by setting the `MII_ENABLE_LUA` environment variable to `yes` when building with `make`.

Any comments or suggestions are welcome.

Pinging @ccoulombe @mboisson